### PR TITLE
Migrate Maven publishing from OSSRH to Central Portal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
   <artifactId>maven-master</artifactId>
   <version>25.1.4-SNAPSHOT</version> <!-- additional version tag required ('parent is also a child module' & versions-maven-plugin) -->
   <packaging>pom</packaging>
+  <name>${project.groupId}:${project.artifactId}</name>
 
   <modules>
     <module>maven_plugin_version-master</module>


### PR DESCRIPTION
OSSRH service will be shut down on June 30th, 2025.

The name in pom.xml is required, otherwise the publishing will fail.

416713