### PR TITLE
Add node to path when using exec-maven-plugin

### DIFF
--- a/maven_rt_plugin_config-master/pom.xml
+++ b/maven_rt_plugin_config-master/pom.xml
@@ -831,6 +831,9 @@
                 <configuration>
                   <executable>${master_node_dir}/node</executable>
                   <workingDirectory>${basedir}</workingDirectory>
+                  <environmentVariables>
+                    <PATH>${master_node_dir}${path.separator}${env.PATH}</PATH>
+                  </environmentVariables>
                   <skip>${master_skip_npm_build_prod}</skip>
                   <arguments>
                     <argument>${master_node_modules_dir}/pnpm/bin/pnpm.cjs</argument>
@@ -852,6 +855,9 @@
                 <configuration>
                   <executable>${master_node_dir}/node</executable>
                   <workingDirectory>${basedir}</workingDirectory>
+                  <environmentVariables>
+                    <PATH>${master_node_dir}${path.separator}${env.PATH}</PATH>
+                  </environmentVariables>
                   <skip>${master_skip_npm_build_dev}</skip>
                   <arguments>
                     <argument>${master_node_modules_dir}/pnpm/bin/pnpm.cjs</argument>
@@ -917,6 +923,9 @@
                 <configuration>
                   <executable>${master_node_dir}/node</executable>
                   <workingDirectory>${basedir}</workingDirectory>
+                  <environmentVariables>
+                    <PATH>${master_node_dir}${path.separator}${env.PATH}</PATH>
+                  </environmentVariables>
                   <skip>${master_skip_karma_test}</skip>
                   <arguments>
                     <argument>${master_node_modules_dir}/pnpm/bin/pnpm.cjs</argument>


### PR DESCRIPTION
The exec-maven-plugin does not add a previously downloaded node installation to the PATH variable. Therefore, the PATH variable needs to be adjusted explicitly to ensure e.g. scout-scripts are executed successfully.

471055